### PR TITLE
Load awt toolkit

### DIFF
--- a/make/jdk/src/classes/build/tools/generatenimbus/Generator.java
+++ b/make/jdk/src/classes/build/tools/generatenimbus/Generator.java
@@ -30,6 +30,9 @@ import javax.xml.stream.XMLStreamReader;
 import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.stream.Collectors;
 
 /**
  * Generates the various Java artifacts based on a SynthModel.
@@ -209,11 +212,13 @@ public class Generator {
         //various palettes of the synth model
         StringBuilder defBuffer = new StringBuilder();
         StringBuilder styleBuffer = new StringBuilder();
-        model.write(defBuffer, styleBuffer, packageNamePrefix);
+        Set<String> classMapper = new HashSet<>();
+        model.write(defBuffer, styleBuffer, classMapper, packageNamePrefix);
 
         Map<String, String> vars = getVariables();
         vars.put("UI_DEFAULT_INIT", defBuffer.toString());
         vars.put("STYLE_INIT", styleBuffer.toString());
+        vars.put("CLASS_MAPPER", classMapper.stream().collect(Collectors.joining()));
         writeSrcFile("Defaults", vars, lafName + "Defaults");
     }
 

--- a/make/jdk/src/classes/build/tools/generatenimbus/SynthModel.java
+++ b/make/jdk/src/classes/build/tools/generatenimbus/SynthModel.java
@@ -28,6 +28,7 @@ package build.tools.generatenimbus;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.util.ArrayList;
+import java.util.Set;
 
 public class SynthModel {
     private UIStyle style;
@@ -79,7 +80,8 @@ public class SynthModel {
         }
     }
 
-    public void write(StringBuilder defBuffer, StringBuilder styleBuffer, String packageName) {
+    public void write(StringBuilder defBuffer, StringBuilder styleBuffer,
+                      Set<String> classesSet, String packageName) {
         defBuffer.append("        //Color palette\n");
         for (UIColor c: colors) defBuffer.append(c.write());
         defBuffer.append('\n');
@@ -99,7 +101,7 @@ public class SynthModel {
         for (UIComponent c: components) {
             String prefix = Utils.escape(c.getKey());
             defBuffer.append("        //Initialize ").append(prefix).append("\n");
-            c.write(defBuffer, styleBuffer, c, prefix, packageName);
+            c.write(defBuffer, styleBuffer, classesSet, c, prefix, packageName);
             defBuffer.append('\n');
         }
     }

--- a/make/jdk/src/classes/build/tools/generatenimbus/SynthModel.java
+++ b/make/jdk/src/classes/build/tools/generatenimbus/SynthModel.java
@@ -81,7 +81,7 @@ public class SynthModel {
     }
 
     public void write(StringBuilder defBuffer, StringBuilder styleBuffer,
-                      Set<String> classesSet, String packageName) {
+                      Set<String> classMapper, String packageName) {
         defBuffer.append("        //Color palette\n");
         for (UIColor c: colors) defBuffer.append(c.write());
         defBuffer.append('\n');
@@ -101,7 +101,7 @@ public class SynthModel {
         for (UIComponent c: components) {
             String prefix = Utils.escape(c.getKey());
             defBuffer.append("        //Initialize ").append(prefix).append("\n");
-            c.write(defBuffer, styleBuffer, classesSet, c, prefix, packageName);
+            c.write(defBuffer, styleBuffer, classMapper, c, prefix, packageName);
             defBuffer.append('\n');
         }
     }

--- a/make/jdk/src/classes/build/tools/generatenimbus/UIIconRegion.java
+++ b/make/jdk/src/classes/build/tools/generatenimbus/UIIconRegion.java
@@ -27,6 +27,7 @@ package build.tools.generatenimbus;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.util.Set;
 
 class UIIconRegion extends UIRegion {
     private String basicKey;
@@ -51,14 +52,15 @@ class UIIconRegion extends UIRegion {
 
     }
 
-    @Override public void write(StringBuilder sb, StringBuilder styleBuffer, UIComponent comp, String prefix, String pkg) {
+    @Override public void write(StringBuilder sb, StringBuilder styleBuffer, Set<String> classMapper,
+                                UIComponent comp, String prefix, String pkg) {
         Dimension size = null;
         String fileNamePrefix = Utils.normalize(prefix) + "Painter";
         // write states ui defaults
         for (UIState state : backgroundStates) {
             Canvas canvas = state.getCanvas();
             if (!canvas.isBlank()) {
-                state.write(sb, prefix, pkg, fileNamePrefix, getKey());
+                state.write(sb, classMapper, prefix, pkg, fileNamePrefix, getKey());
                 size = canvas.getSize();
             }
         }

--- a/make/jdk/src/classes/build/tools/generatenimbus/UIRegion.java
+++ b/make/jdk/src/classes/build/tools/generatenimbus/UIRegion.java
@@ -30,6 +30,7 @@ import javax.xml.stream.XMLStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 class UIRegion {
     String name;
@@ -147,7 +148,7 @@ class UIRegion {
         return false;
     }
 
-    public void write(StringBuilder sb, StringBuilder styleBuffer,
+    public void write(StringBuilder sb, StringBuilder styleBuffer, Set<String> classMapper,
                       UIComponent comp, String prefix, String pkg) {
         // write content margins
         sb.append(String.format("        d.put(\"%s.contentMargins\", %s);\n",
@@ -219,13 +220,13 @@ class UIRegion {
         }
         // write states ui defaults
         for (UIState state : backgroundStates) {
-            state.write(sb, prefix, pkg, fileName, "background");
+            state.write(sb, classMapper, prefix, pkg, fileName, "background");
         }
         for (UIState state : foregroundStates) {
-            state.write(sb, prefix, pkg, fileName, "foreground");
+            state.write(sb, classMapper, prefix, pkg, fileName, "foreground");
         }
         for (UIState state : borderStates) {
-            state.write(sb, prefix, pkg, fileName, "border");
+            state.write(sb, classMapper, prefix, pkg, fileName, "border");
         }
 
         // handle sub regions
@@ -238,7 +239,7 @@ class UIRegion {
             if (subreg instanceof UIComponent) {
                 c = (UIComponent) subreg;
             }
-            subreg.write(sb, styleBuffer, c, p, pkg);
+            subreg.write(sb, styleBuffer, classMapper, c, p, pkg);
         }
     }
 }

--- a/make/jdk/src/classes/build/tools/generatenimbus/UIState.java
+++ b/make/jdk/src/classes/build/tools/generatenimbus/UIState.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 class UIState {
     private String stateKeys;
@@ -99,17 +100,19 @@ class UIState {
         return cachedName;
     }
 
-    public void write(StringBuilder sb, String prefix, String pkg, String fileNamePrefix, String painterPrefix) {
+    public void write(StringBuilder sb, Set<String> classMapper, String prefix,
+                      String pkg, String fileNamePrefix, String painterPrefix) {
         String statePrefix = prefix + "[" + getName() + "]";
         // write state style
         sb.append(style.write(statePrefix + '.'));
         // write painter
         if (hasCanvas()) {
-            writeLazyPainter(sb, statePrefix, pkg, fileNamePrefix, painterPrefix);
+            writeLazyPainter(sb, classMapper, statePrefix, pkg, fileNamePrefix, painterPrefix);
         }
     }
 
-    private void writeLazyPainter(StringBuilder sb, String statePrefix, String packageNamePrefix, String fileNamePrefix, String painterPrefix) {
+    private void writeLazyPainter(StringBuilder sb, Set<String> classMapper, String statePrefix,
+                                  String packageNamePrefix, String fileNamePrefix, String painterPrefix) {
         String cacheModeString = "AbstractRegionPainter.PaintContext.CacheMode." + style.getCacheMode();
         String stateConstant = Utils.statesToConstantName(painterPrefix + "_" + stateKeys);
         sb.append(String.format(
@@ -119,5 +122,7 @@ class UIState {
                 canvas.getSize().write(false), inverted, cacheModeString,
                 Utils.formatDouble(style.getMaxHozCachedImgScaling()),
                 Utils.formatDouble(style.getMaxVertCachedImgScaling())));
+        classMapper.add(String.format("                    case \"%1$s.%2$s\" : return new %1$s.%2$s(ctx, which);\n",
+                packageNamePrefix, fileNamePrefix));
     }
 }

--- a/src/demo/share/java2d/J2DBench/src/j2dbench/ResultSet.java
+++ b/src/demo/share/java2d/J2DBench/src/j2dbench/ResultSet.java
@@ -81,7 +81,6 @@ public class ResultSet {
         "java.library.path",
         "java.io.tmpdir",
         "java.util.prefs.PreferencesFactory",
-        "sun.java2d.fontpath",
         "sun.boot.library.path",
     };
 
@@ -100,8 +99,6 @@ public class ResultSet {
      * java.vm.specification.vendor
      * java.vm.specification.version
      * java.vm.vendor
-     * java.awt.graphicsenv
-     * java.awt.printerjob
      * user.language
      * sun.os.patch.level
      * sun.arch.data.model

--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -206,15 +206,6 @@ Java_java_lang_System_initProperties(JNIEnv *env, jclass cla, jobject props)
                                             JVM_CLASSFILE_MINOR_VERSION);
     PUTPROP(props, "java.class.version", buf);
 
-    if (sprops->awt_toolkit) {
-        PUTPROP(props, "awt.toolkit", sprops->awt_toolkit);
-    }
-#ifdef MACOSX
-    if (sprops->awt_headless) {
-        PUTPROP(props, "java.awt.headless", sprops->awt_headless);
-    }
-#endif
-
     /* os properties */
     PUTPROP(props, "os.name", sprops->os_name);
     PUTPROP(props, "os.version", sprops->os_version);
@@ -320,17 +311,6 @@ Java_java_lang_System_initProperties(JNIEnv *env, jclass cla, jobject props)
                     sprops->patch_level);
 
     /* Java2D properties */
-    /* Note: java.awt.graphicsenv is an implementation private property which
-     * just happens to have a java.* name because it is referenced in
-     * a java.awt class. It is the mechanism by which the implementation
-     * finds the appropriate class in the JRE for the platform.
-     * It is explicitly not designed to be overridden by clients as
-     * a way of replacing the implementation class, and in any case
-     * the mechanism by which the class is loaded is constrained to only
-     * find and load classes that are part of the JRE.
-     * This property may be removed if that mechanism is redesigned
-     */
-    PUTPROP(props, "java.awt.graphicsenv", sprops->graphics_env);
     if (sprops->font_dir != NULL) {
         PUTPROP_ForPlatformNString(props,
                                    "sun.java2d.fontpath", sprops->font_dir);

--- a/src/java.base/share/native/libjava/java_props.h
+++ b/src/java.base/share/native/libjava/java_props.h
@@ -75,8 +75,6 @@ typedef struct {
     char *timezone;
 
     char *printerJob;
-    char *graphics_env;
-    char *awt_toolkit;
 
     char *unicode_encoding;     /* The default endianness of unicode
                                     i.e. UnicodeBig or UnicodeLittle   */
@@ -116,8 +114,6 @@ typedef struct {
     char *gopherPort;
 
     char *exceptionList;
-
-    char *awt_headless;  /* java.awt.headless setting, if NULL (default) will not be set */
 #endif
 
 } java_props_t;

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -434,19 +434,6 @@ GetJavaProperties(JNIEnv *env)
     /* patches/service packs installed */
     sprops.patch_level = "unknown";
 
-    /* Java 2D/AWT properties */
-#ifdef MACOSX
-    // Always the same GraphicsEnvironment and Toolkit on Mac OS X
-    sprops.graphics_env = "sun.awt.CGraphicsEnvironment";
-    sprops.awt_toolkit = "sun.lwawt.macosx.LWCToolkit";
-
-    // check if we're in a GUI login session and set java.awt.headless=true if not
-    sprops.awt_headless = isInAquaSession() ? NULL : "true";
-#else
-    sprops.graphics_env = "sun.awt.X11GraphicsEnvironment";
-    sprops.awt_toolkit = "sun.awt.X11.XToolkit";
-#endif
-
     /* This is used only for debugging of font problems. */
     v = getenv("JAVA2D_FONTPATH");
     sprops.font_dir = v ? v : NULL;

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -359,9 +359,6 @@ GetJavaProperties(JNIEnv* env)
         return &sprops;
     }
 
-    /* AWT properties */
-    sprops.awt_toolkit = "sun.awt.windows.WToolkit";
-
     /* tmp dir */
     {
         WCHAR tmpdir[MAX_PATH + 1];
@@ -372,9 +369,6 @@ GetJavaProperties(JNIEnv* env)
 
     /* Printing properties */
     sprops.printerJob = "sun.awt.windows.WPrinterJob";
-
-    /* Java2D properties */
-    sprops.graphics_env = "sun.awt.Win32GraphicsEnvironment";
 
     {    /* This is used only for debugging of font problems. */
         WCHAR *path = _wgetenv(L"JAVA2D_FONTPATH");

--- a/src/java.desktop/macosx/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/macosx/classes/sun/awt/PlatformGraphicsInfo.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Toolkit;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class PlatformGraphicsInfo {
+
+    static {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            System.loadLibrary("awt");
+            return null;
+        });
+    }
+
+    public static GraphicsEnvironment createGE() {
+        return new CGraphicsEnvironment();
+    }
+
+    public static Toolkit createToolkit() {
+        return new sun.lwawt.macosx.LWCToolkit();
+    }
+
+    /**
+     * Returns true if the WindowServer is available, false otherwise.
+     *
+     * @return true if the WindowServer is available, false otherwise
+     */
+    public static native boolean isInAquaSession();
+
+    public static boolean getDefaultHeadlessProperty() {
+         return !isInAquaSession();
+    }
+
+    /*
+     * Called from java.awt.GraphicsEnvironment when
+     * getDefaultHeadlessProperty() has returned true, and
+     * the application has called an API that requires headful.
+     */
+    public static String getDefaultHeadlessMessage() {
+        return
+            "\nThe application is not running in a desktop session,\n" +
+            "but this program performed an operation which requires it.";
+    }
+
+}

--- a/src/java.desktop/macosx/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/macosx/classes/sun/awt/PlatformGraphicsInfo.java
@@ -29,6 +29,8 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import sun.font.FontManager;
+import sun.font.CFontManager;
 
 public class PlatformGraphicsInfo {
 
@@ -45,6 +47,10 @@ public class PlatformGraphicsInfo {
 
     public static Toolkit createToolkit() {
         return new sun.lwawt.macosx.LWCToolkit();
+    }
+
+    public static FontManager createFontManager() {
+        return new CFontManager();
     }
 
     /**

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -104,6 +104,7 @@ import sun.awt.AWTAccessor;
 import sun.awt.AppContext;
 import sun.awt.CGraphicsDevice;
 import sun.awt.LightweightFrame;
+import sun.awt.PlatformGraphicsInfo;
 import sun.awt.SunToolkit;
 import sun.awt.datatransfer.DataTransferer;
 import sun.awt.dnd.SunDragSourceContextPeer;
@@ -163,7 +164,9 @@ public final class LWCToolkit extends LWToolkit {
             }
         });
 
-        if (!GraphicsEnvironment.isHeadless() && !isInAquaSession()) {
+        if (!GraphicsEnvironment.isHeadless() &&
+            !PlatformGraphicsInfo.isInAquaSession())
+        {
             throw new AWTError("WindowServer is not available");
         }
 
@@ -187,10 +190,16 @@ public final class LWCToolkit extends LWToolkit {
     private static final boolean inAWT;
 
     public LWCToolkit() {
-        areExtraMouseButtonsEnabled = Boolean.parseBoolean(System.getProperty("sun.awt.enableExtraMouseButtons", "true"));
-        //set system property if not yet assigned
-        System.setProperty("sun.awt.enableExtraMouseButtons", ""+areExtraMouseButtonsEnabled);
-        initAppkit(ThreadGroupUtils.getRootThreadGroup(), GraphicsEnvironment.isHeadless());
+        final String extraButtons = "sun.awt.enableExtraMouseButtons";
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            areExtraMouseButtonsEnabled =
+                 Boolean.parseBoolean(System.getProperty(extraButtons, "true"));
+            //set system property if not yet assigned
+            System.setProperty(extraButtons, ""+areExtraMouseButtonsEnabled);
+            initAppkit(ThreadGroupUtils.getRootThreadGroup(),
+                       GraphicsEnvironment.isHeadless());
+            return null;
+        });
     }
 
     /*
@@ -894,13 +903,6 @@ public final class LWCToolkit extends LWToolkit {
      * @return true if AWT toolkit is embedded, false otherwise
      */
     public static native boolean isEmbedded();
-
-    /**
-     * Returns true if the WindowServer is available, false otherwise.
-     *
-     * @return true if the WindowServer is available, false otherwise
-     */
-    private static native boolean isInAquaSession();
 
     /*
      * Activates application ignoring other apps.

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -833,14 +833,14 @@ Java_sun_lwawt_macosx_LWCToolkit_isEmbedded
 }
 
 /*
- * Class:     sun_lwawt_macosx_LWCToolkit
+ * Class:     sun_awt_PlatformGraphicsInfo
  * Method:    isInAquaSession
  * Signature: ()Z
  */
 JNIEXPORT jboolean JNICALL
-Java_sun_lwawt_macosx_LWCToolkit_isInAquaSession
+Java_sun_awt_PlatformGraphicsInfo_isInAquaSession
 (JNIEnv *env, jclass klass) {
-    // copied from java.base/macosx/native/libjava/java_props_macosx.c
+    // originally from java.base/macosx/native/libjava/java_props_macosx.c
     // environment variable to bypass the aqua session check
     char *ev = getenv("AWT_FORCE_HEADFUL");
     if (ev && (strncasecmp(ev, "true", 4) == 0)) {

--- a/src/java.desktop/share/classes/javax/swing/UIDefaults.java
+++ b/src/java.desktop/share/classes/javax/swing/UIDefaults.java
@@ -1534,6 +1534,8 @@ public class UIDefaults extends Hashtable<Object,Object>
                 return javax.swing.plaf.metal.MetalTreeUI.createUI(comp);
             case "javax.swing.plaf.metal.MetalRootPaneUI":
                 return javax.swing.plaf.metal.MetalRootPaneUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalMenuBarUI":
+                return javax.swing.plaf.metal.MetalMenuBarUI.createUI(comp);
             // SynthLookAndFeel
             case "javax.swing.plaf.synth.SynthLookAndFeel":
                 return javax.swing.plaf.synth.SynthLookAndFeel.createUI(comp);

--- a/src/java.desktop/share/classes/javax/swing/UIDefaults.java
+++ b/src/java.desktop/share/classes/javax/swing/UIDefaults.java
@@ -781,6 +781,14 @@ public class UIDefaults extends Hashtable<Object,Object>
     public ComponentUI getUI(JComponent target) {
 
         Object cl = get("ClassLoader");
+
+        if (cl == null) {
+            ComponentUI componentUI = createComponentUI(target);
+            if (componentUI != null) {
+                return componentUI;
+            }
+        }
+
         ClassLoader uiClassLoader =
             (cl != null) ? (ClassLoader)cl : target.getClass().getClassLoader();
         Class<? extends ComponentUI> uiClass = getUIClass(target.getUIClassID(), uiClassLoader);
@@ -1385,4 +1393,152 @@ public class UIDefaults extends Hashtable<Object,Object>
         }
     }
 
+    private ComponentUI createComponentUI(JComponent comp) {
+
+        String className = (String)get(comp.getUIClassID());
+
+        if (className == null) {
+            return null;
+        }
+
+        switch (className) {
+            // BasicMetalLookAndFeel
+            case "javax.swing.plaf.basic.BasicButtonUI":
+                return javax.swing.plaf.basic.BasicButtonUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicCheckBoxUI":
+                return javax.swing.plaf.basic.BasicCheckBoxUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicColorChooserUI":
+                return javax.swing.plaf.basic.BasicColorChooserUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicFormattedTextFieldUI":
+                return javax.swing.plaf.basic.BasicFormattedTextFieldUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicMenuBarUI":
+                return javax.swing.plaf.basic.BasicMenuBarUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicMenuUI":
+                return javax.swing.plaf.basic.BasicMenuUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicMenuItemUI":
+                return javax.swing.plaf.basic.BasicMenuItemUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicCheckBoxMenuItemUI":
+                return javax.swing.plaf.basic.BasicCheckBoxMenuItemUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicRadioButtonMenuItemUI":
+                return javax.swing.plaf.basic.BasicRadioButtonMenuItemUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicRadioButtonUI":
+                return javax.swing.plaf.basic.BasicRadioButtonUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicToggleButtonUI":
+                return javax.swing.plaf.basic.BasicToggleButtonUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicPopupMenuUI":
+                return javax.swing.plaf.basic.BasicPopupMenuUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicProgressBarUI":
+                return javax.swing.plaf.basic.BasicProgressBarUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicScrollBarUI":
+                return javax.swing.plaf.basic.BasicScrollBarUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicScrollPaneUI":
+                return javax.swing.plaf.basic.BasicScrollPaneUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicSplitPaneUI":
+                return javax.swing.plaf.basic.BasicSplitPaneUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicSliderUI":
+                return javax.swing.plaf.basic.BasicSliderUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicSeparatorUI":
+                return javax.swing.plaf.basic.BasicSeparatorUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicSpinnerUI":
+                return javax.swing.plaf.basic.BasicSpinnerUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicToolBarSeparatorUI":
+                return javax.swing.plaf.basic.BasicToolBarSeparatorUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicPopupMenuSeparatorUI":
+                return javax.swing.plaf.basic.BasicPopupMenuSeparatorUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicTabbedPaneUI":
+                return javax.swing.plaf.basic.BasicTabbedPaneUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicTextAreaUI":
+                return javax.swing.plaf.basic.BasicTextAreaUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicTextFieldUI":
+                return javax.swing.plaf.basic.BasicTextFieldUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicPasswordFieldUI":
+                return javax.swing.plaf.basic.BasicPasswordFieldUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicTextPaneUI":
+                return javax.swing.plaf.basic.BasicTextPaneUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicEditorPaneUI":
+                return javax.swing.plaf.basic.BasicEditorPaneUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicTreeUI":
+                return javax.swing.plaf.basic.BasicTreeUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicLabelUI":
+                return javax.swing.plaf.basic.BasicLabelUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicListUI":
+                return javax.swing.plaf.basic.BasicListUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicToolBarUI":
+                return javax.swing.plaf.basic.BasicToolBarUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicToolTipUI":
+                return javax.swing.plaf.basic.BasicToolTipUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicComboBoxUI":
+                return javax.swing.plaf.basic.BasicComboBoxUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicTableUI":
+                return javax.swing.plaf.basic.BasicTableUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicTableHeaderUI":
+                return javax.swing.plaf.basic.BasicTableHeaderUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicInternalFrameUI":
+                return javax.swing.plaf.basic.BasicInternalFrameUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicDesktopPaneUI":
+                return javax.swing.plaf.basic.BasicDesktopPaneUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicDesktopIconUI":
+                return javax.swing.plaf.basic.BasicDesktopIconUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicFileChooserUI":
+                return javax.swing.plaf.basic.BasicFileChooserUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicOptionPaneUI":
+                return javax.swing.plaf.basic.BasicOptionPaneUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicPanelUI":
+                return javax.swing.plaf.basic.BasicPanelUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicViewportUI":
+                return javax.swing.plaf.basic.BasicViewportUI.createUI(comp);
+            case "javax.swing.plaf.basic.BasicRootPaneUI":
+                return javax.swing.plaf.basic.BasicRootPaneUI.createUI(comp);
+            // MetalLookAndFeel
+            case "javax.swing.plaf.metal.MetalButtonUI":
+                return javax.swing.plaf.metal.MetalButtonUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalCheckBoxUI":
+                return javax.swing.plaf.metal.MetalCheckBoxUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalComboBoxUI":
+                return javax.swing.plaf.metal.MetalComboBoxUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalDesktopIconUI":
+                return javax.swing.plaf.metal.MetalDesktopIconUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalFileChooserUI":
+                return javax.swing.plaf.metal.MetalFileChooserUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalInternalFrameUI":
+                return javax.swing.plaf.metal.MetalInternalFrameUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalLabelUI":
+                return javax.swing.plaf.metal.MetalLabelUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalPopupMenuSeparatorUI":
+                return javax.swing.plaf.metal.MetalPopupMenuSeparatorUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalProgressBarUI":
+                return javax.swing.plaf.metal.MetalProgressBarUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalRadioButtonUI":
+                return javax.swing.plaf.metal.MetalRadioButtonUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalScrollBarUI":
+                return javax.swing.plaf.metal.MetalScrollBarUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalScrollPaneUI":
+                return javax.swing.plaf.metal.MetalScrollPaneUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalSeparatorUI":
+                return javax.swing.plaf.metal.MetalSeparatorUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalSliderUI":
+                return javax.swing.plaf.metal.MetalSliderUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalSplitPaneUI":
+                return javax.swing.plaf.metal.MetalSplitPaneUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalTabbedPaneUI":
+                return javax.swing.plaf.metal.MetalTabbedPaneUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalTextFieldUI":
+                return javax.swing.plaf.metal.MetalTextFieldUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalToggleButtonUI":
+                return javax.swing.plaf.metal.MetalToggleButtonUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalToolBarUI":
+                return javax.swing.plaf.metal.MetalToolBarUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalToolTipUI":
+                return javax.swing.plaf.metal.MetalToolTipUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalTreeUI":
+                return javax.swing.plaf.metal.MetalTreeUI.createUI(comp);
+            case "javax.swing.plaf.metal.MetalRootPaneUI":
+                return javax.swing.plaf.metal.MetalRootPaneUI.createUI(comp);
+            // SynthLookAndFeel
+            case "javax.swing.plaf.synth.SynthLookAndFeel":
+                return javax.swing.plaf.synth.SynthLookAndFeel.createUI(comp);
+            default:
+                return null;
+        }
+    }
 }

--- a/src/java.desktop/share/classes/javax/swing/UIManager.java
+++ b/src/java.desktop/share/classes/javax/swing/UIManager.java
@@ -627,6 +627,9 @@ public class UIManager implements Serializable
         if ("javax.swing.plaf.metal.MetalLookAndFeel".equals(className)) {
             // Avoid reflection for the common case of metal.
             setLookAndFeel(new javax.swing.plaf.metal.MetalLookAndFeel());
+        } else if ("javax.swing.plaf.nimbus.NimbusLookAndFeel".equals(className)) {
+            // Avoid reflection for the common case of nimbus.
+            setLookAndFeel(new javax.swing.plaf.nimbus.NimbusLookAndFeel());
         }
         else {
             Class<?> lnfClass = SwingUtilities.loadSystemClass(className);

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template
@@ -403,6 +403,11 @@ ${UI_DEFAULT_INIT}
                 // See if we should use a separate ClassLoader
                 if (table == null || !((cl = table.get("ClassLoader"))
                                        instanceof ClassLoader)) {
+                    AbstractRegionPainter regionPainter =
+                        createPainter(className, ctx, which);
+                    if (regionPainter != null) {
+                        return regionPainter;
+                    }
                     cl = Thread.currentThread().
                                 getContextClassLoader();
                     if (cl == null) {
@@ -423,6 +428,18 @@ ${UI_DEFAULT_INIT}
             } catch (Exception e) {
                 e.printStackTrace();
                 return null;
+            }
+        }
+
+        /**
+        * Map Painter classes to objects to avoid reflection usage
+        */
+        private static AbstractRegionPainter createPainter(
+            String className, AbstractRegionPainter.PaintContext ctx, int which) {
+                switch(className) {
+${CLASS_MAPPER}
+                    default:
+                        return null;
             }
         }
     }

--- a/src/java.desktop/share/classes/sun/font/FontManagerFactory.java
+++ b/src/java.desktop/share/classes/sun/font/FontManagerFactory.java
@@ -34,6 +34,8 @@ import java.security.PrivilegedAction;
 
 import sun.security.action.GetPropertyAction;
 
+import sun.awt.PlatformGraphicsInfo;
+
 
 /**
  * Factory class used to retrieve a valid FontManager instance for the current
@@ -48,17 +50,6 @@ public final class FontManagerFactory {
 
     /** Our singleton instance. */
     private static FontManager instance = null;
-
-    private static final String DEFAULT_CLASS;
-    static {
-        if (FontUtilities.isWindows) {
-            DEFAULT_CLASS = "sun.awt.Win32FontManager";
-        } else if (FontUtilities.isMacOSX) {
-            DEFAULT_CLASS = "sun.font.CFontManager";
-            } else {
-            DEFAULT_CLASS = "sun.awt.X11FontManager";
-            }
-    }
 
     /**
      * Get a valid FontManager implementation for the current platform.
@@ -76,8 +67,13 @@ public final class FontManagerFactory {
             public Object run() {
                 try {
                     String fmClassName =
-                            System.getProperty("sun.font.fontmanager",
-                                               DEFAULT_CLASS);
+                            System.getProperty("sun.font.fontmanager");
+
+                    if (fmClassName == null) {
+                        instance = PlatformGraphicsInfo.createFontManager();
+                        return null;
+                    }
+
                     ClassLoader cl = ClassLoader.getSystemClassLoader();
                     Class<?> fmClass = Class.forName(fmClassName, true, cl);
                     instance =

--- a/src/java.desktop/share/classes/sun/java2d/pipe/RenderingEngine.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/RenderingEngine.java
@@ -131,12 +131,7 @@ public abstract class RenderingEngine {
             }
         }
         if (reImpl == null) {
-            final String marlinREClass = "sun.java2d.marlin.DMarlinRenderingEngine";
-            try {
-                Class<?> cls = Class.forName(marlinREClass);
-                reImpl = (RenderingEngine) cls.getConstructor().newInstance();
-            } catch (ReflectiveOperationException ignored1) {
-            }
+            reImpl = new sun.java2d.marlin.DMarlinRenderingEngine();
         }
 
         if (reImpl == null) {

--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Toolkit;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class PlatformGraphicsInfo {
+
+    public static GraphicsEnvironment createGE() {
+        return new X11GraphicsEnvironment();
+    }
+
+    public static Toolkit createToolkit() {
+        return new sun.awt.X11.XToolkit();
+    }
+
+    /**
+      * Called from java.awt.GraphicsEnvironment when
+      * to check if on this platform, the JDK should default to
+      * headless mode, in the case the application did specify
+      * a value for the java.awt.headless system property.
+      */
+    public static boolean getDefaultHeadlessProperty() {
+        return
+            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+
+               final String display = System.getenv("DISPLAY");
+               return  display == null || display.trim().isEmpty();
+            });
+    }
+
+    /**
+      * Called from java.awt.GraphicsEnvironment when
+      * getDefaultHeadlessProperty() has returned true, and
+      * the application has called an API that requires headful.
+      */
+    public static String getDefaultHeadlessMessage() {
+        return
+            "\nNo X11 DISPLAY variable was set,\n" +
+            "but this program performed an operation which requires it.";
+    }
+}

--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -29,6 +29,8 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import sun.font.FontManager;
+import sun.awt.X11FontManager;
 
 public class PlatformGraphicsInfo {
 
@@ -38,6 +40,10 @@ public class PlatformGraphicsInfo {
 
     public static Toolkit createToolkit() {
         return new sun.awt.X11.XToolkit();
+    }
+
+    public static FontManager createFontManager() {
+        return new X11FontManager();
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -342,10 +342,14 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
 
             arrowCursor = XlibWrapper.XCreateFontCursor(XToolkit.getDisplay(),
                 XCursorFontConstants.XC_arrow);
-            areExtraMouseButtonsEnabled = Boolean.parseBoolean(System.getProperty("sun.awt.enableExtraMouseButtons", "true"));
-            //set system property if not yet assigned
-            System.setProperty("sun.awt.enableExtraMouseButtons", ""+areExtraMouseButtonsEnabled);
-
+            final String extraButtons = "sun.awt.enableExtraMouseButtons";
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                areExtraMouseButtonsEnabled =
+                    Boolean.parseBoolean(System.getProperty(extraButtons, "true"));
+                //set system property if not yet assigned
+                System.setProperty(extraButtons, ""+areExtraMouseButtonsEnabled);
+                return null;
+            });
             // Detect display mode changes
             XlibWrapper.XSelectInput(XToolkit.getDisplay(), XToolkit.getDefaultRootWindow(), XConstants.StructureNotifyMask);
             XToolkit.addEventDispatcher(XToolkit.getDefaultRootWindow(), new XEventDispatcher() {

--- a/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
+++ b/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
@@ -116,8 +116,6 @@ AWT_OnLoad(JavaVM *vm, void *reserved)
     struct utsname name;
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(vm, JNI_VERSION_1_2);
     void *v;
-    jstring fmanager = NULL;
-    jstring fmProp = NULL;
 
     if (awtHandle != NULL) {
         /* Avoid several loading attempts */
@@ -133,29 +131,15 @@ AWT_OnLoad(JavaVM *vm, void *reserved)
     p = strrchr(buf, '/');
 #endif
     /*
-     * The code below is responsible for:
-     * 1. Loading appropriate awt library, i.e. libawt_xawt or libawt_headless
-     * 2. Set the "sun.font.fontmanager" system property.
+     * The code below is responsible for
+     * loading appropriate awt library, i.e. libawt_xawt or libawt_headless
      */
 
-    fmProp = (*env)->NewStringUTF(env, "sun.font.fontmanager");
-    CHECK_EXCEPTION_FATAL(env, "Could not allocate font manager property");
-
 #ifdef MACOSX
-        fmanager = (*env)->NewStringUTF(env, "sun.font.CFontManager");
         tk = LWAWT_PATH;
 #else
-        fmanager = (*env)->NewStringUTF(env, "sun.awt.X11FontManager");
         tk = XAWT_PATH;
 #endif
-    CHECK_EXCEPTION_FATAL(env, "Could not allocate font manager name");
-
-    if (fmanager && fmProp) {
-        JNU_CallStaticMethodByName(env, NULL, "java/lang/System", "setProperty",
-                                   "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
-                                   fmProp, fmanager);
-        CHECK_EXCEPTION_FATAL(env, "Could not allocate set properties");
-    }
 
 #ifndef MACOSX
     if (AWTIsHeadless()) {
@@ -167,14 +151,6 @@ AWT_OnLoad(JavaVM *vm, void *reserved)
     /* Calculate library name to load */
     strncpy(p, tk, MAXPATHLEN-len-1);
 #endif
-
-    if (fmProp) {
-        (*env)->DeleteLocalRef(env, fmProp);
-    }
-    if (fmanager) {
-        (*env)->DeleteLocalRef(env, fmanager);
-    }
-
 
 #ifndef STATIC_BUILD
     jstring jbuf = JNU_NewStringPlatform(env, buf);

--- a/src/java.desktop/windows/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/windows/classes/sun/awt/PlatformGraphicsInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Toolkit;
+
+public class PlatformGraphicsInfo {
+
+    public static GraphicsEnvironment createGE() {
+        return new Win32GraphicsEnvironment();
+    }
+
+    public static Toolkit createToolkit() {
+        return new sun.awt.windows.WToolkit();
+    }
+
+    public static boolean getDefaultHeadlessProperty() {
+        // On Windows, we assume we can always create headful apps.
+        // Here is where we can add code that would actually check.
+        return false;
+    }
+
+    /*
+     * Called from java.awt.GraphicsEnvironment when
+     * getDefaultHeadlessProperty() has returned true, and
+     * the application has called an API that requires headful.
+     */
+    public static String getDefaultHeadlessMessage() {
+        return
+            "\nThe application does not have desktop access,\n" +
+            "but this program performed an operation which requires it.";
+    }
+
+}

--- a/src/java.desktop/windows/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/windows/classes/sun/awt/PlatformGraphicsInfo.java
@@ -27,6 +27,8 @@ package sun.awt;
 
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
+import sun.font.FontManager;
+import sun.awt.Win32FontManager;
 
 public class PlatformGraphicsInfo {
 
@@ -36,6 +38,10 @@ public class PlatformGraphicsInfo {
 
     public static Toolkit createToolkit() {
         return new sun.awt.windows.WToolkit();
+    }
+
+    public static FontManager createFontManager() {
+        return new Win32FontManager();
     }
 
     public static boolean getDefaultHeadlessProperty() {

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -245,10 +245,13 @@ public final class WToolkit extends SunToolkit implements Runnable {
         ThreadGroup rootTG = AccessController.doPrivileged(
                 (PrivilegedAction<ThreadGroup>) ThreadGroupUtils::getRootThreadGroup);
         if (!startToolkitThread(this, rootTG)) {
-            String name = "AWT-Windows";
-            Thread toolkitThread = new Thread(rootTG, this, name, 0, false);
-            toolkitThread.setDaemon(true);
-            toolkitThread.start();
+            final String name = "AWT-Windows";
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                Thread toolkitThread = new Thread(rootTG, this, name, 0, false);
+                toolkitThread.setDaemon(true);
+                toolkitThread.start();
+                return null;
+            });
         }
 
         try {
@@ -264,10 +267,14 @@ public final class WToolkit extends SunToolkit implements Runnable {
         // Enabled "live resizing" by default.  It remains controlled
         // by the native system though.
         setDynamicLayout(true);
-
-        areExtraMouseButtonsEnabled = Boolean.parseBoolean(System.getProperty("sun.awt.enableExtraMouseButtons", "true"));
-        //set system property if not yet assigned
-        System.setProperty("sun.awt.enableExtraMouseButtons", ""+areExtraMouseButtonsEnabled);
+        final String extraButtons = "sun.awt.enableExtraMouseButtons";
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            areExtraMouseButtonsEnabled =
+                 Boolean.parseBoolean(System.getProperty(extraButtons, "true"));
+            //set system property if not yet assigned
+            System.setProperty(extraButtons, ""+areExtraMouseButtonsEnabled);
+            return null;
+        });
         setExtraMouseButtonsEnabledNative(areExtraMouseButtonsEnabled);
     }
 

--- a/test/jdk/java/awt/GraphicsEnvironment/CheckGraphicsEnvSystemProperty.java
+++ b/test/jdk/java/awt/GraphicsEnvironment/CheckGraphicsEnvSystemProperty.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8130266
+ * @summary verify the GraphicsEnvironmement implementation class name is not
+ *          polluting system properties
+ */
+
+public class CheckGraphicsEnvSystemProperty {
+
+     public static void main(String[] args) {
+         String geProp = System.getProperty("java.awt.graphicsenv");
+         if (geProp != null) {
+             throw new RuntimeException("geProp = " + geProp);
+         }
+     }
+}

--- a/test/jdk/java/awt/Toolkit/ToolkitPropertyTest/CheckToolkitSystemProperty.java
+++ b/test/jdk/java/awt/Toolkit/ToolkitPropertyTest/CheckToolkitSystemProperty.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8212700
+ * @summary verify the AWT Toolkit implementation class name is not
+ *          polluting system properties
+ */
+
+public class CheckToolkitSystemProperty {
+
+     public static void main(String[] args) {
+         String tkProp = System.getProperty("awt.toolkit");
+         if (tkProp != null) {
+             throw new RuntimeException("tkProp = " + tkProp);
+         }
+     }
+}


### PR DESCRIPTION
The pull request consists of the following parts:
Backports of
- 8130266 Change the mechanism by which JDK loads the platform-specific GraphicsEnvironment class
- 8212700 Change the mechanism by which JDK loads the platform-specific AWT Toolkit

The fallback to reflection is provided for case when `java.awt.graphicsenv` and `awt.toolkit` Java properties are set.

Fix for the
- 8273581 Change the mechanism by which JDK loads the platform-specific FontManager class

The fallback to reflection is provided for case when `sun.font.fontmanager` Java property is set.

Loading Basic, Metal, and Synth component UIs directly without reflection in case the class loader is not set in method UIDefaults.getUI(Class tartet) method.

Setting Nimbus L&F directly without using reflection in UIManager.setLookAndFeel(String className) method.

TBD: avoid using reflection in NimbusDefaults.LazyPainter.createValue(UIDefaults table):
https://github.com/AlexanderScherbatiy/labs-openjdk-11/blob/74ba8f2dec31c8b0bdb2b86515a855d5215b0c8c/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template#L414